### PR TITLE
Placate the staid nitpickers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shawshank"
 description = "An efficient, generic internment structure."
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Samuel Fredrickson <kinghajj@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ extern crate shawshank;
 
 fn main() {
     // prototypical motivation: string internment
-    let mut sp = shawshank::string_prison();
+    let mut sp = shawshank::string_arena_set();
     assert_eq!(sp.intern("hello"), Ok(0));
     assert_eq!(sp.intern("world"), Ok(1));
     assert_eq!(sp.intern("hello"), Ok(0));
     assert_eq!(sp.resolve(1), Ok("world"));
 
     // byte vectors work, too
-    let mut bp = shawshank::byte_prison();
+    let mut bp = shawshank::byte_arena_set();
     assert_eq!(bp.intern(&[0, 1, 2][..]), Ok(0));
 
     // even Box<T>

--- a/src/arena_set.rs
+++ b/src/arena_set.rs
@@ -22,7 +22,7 @@ use traits::Map;
 ///     Vacant(usize),
 ///     Occupied(T),
 /// }
-/// pub struct StringPrison {
+/// pub struct StringArenaSet {
 ///     map: HashMap<&'static str, usize>,
 ///     interned: Vec<Slot<String>>,
 ///     head: usize,
@@ -46,14 +46,14 @@ use traits::Map;
 /// index of the next, etc., effectively forming a linked list, with `!0` as the
 /// end-of-list marker. This allows vacant slots to be efficiently reclaimed
 /// before appending to the vector. This is the same technique employed by
-/// [`vec_arena`]. Another name for `Prison` could be `ArenaSet`.
+/// [`vec_arena`].
 ///
 /// # Custom ID Types
 ///
 /// By default, the ID type parameter `I` is `usize`, the type of a `Vec`
 /// index. One problem with `usize`, of course, is lack of type safety. One
 /// could wrap the IDs inside tuple structs, so that different domains share the
-/// same `Prison`. Some workloads, however, may have domains with disjoint
+/// same `ArenaSet`. Some workloads, however, may have domains with disjoint
 /// sets or much lower cardinality than `usize` provides. In such cases,
 /// more space can be saved by storing a smaller-than-`usize` `I` in the
 /// internal map, and converting to and from `usize` as needed. [`intern`]
@@ -92,14 +92,14 @@ use traits::Map;
 ///   * `I`: The "ID" type to uniquely resolve interned items.
 ///   * `M`: The type used to [`Map`] `O::Target`s to `I`s.
 ///
-/// [`intern`]: struct.Prison.html#method.intern
+/// [`intern`]: struct.ArenaSet.html#method.intern
 /// [`Error::FromIdFailed`]: enum.Error.html#variant.FromIdFailed
 /// [`Error::ToIdFailed`]: enum.Error.html#variant.ToIdFailed
 /// [`Error::IdOverflow`]: enum.Error.html#variant.IdOverflow
 /// [`Map`]: trait.Map.html
 /// [`custom_intern_id!`]: macro.custom_intern_id.html
 /// [`vec_arena`]: https://github.com/stjepang/vec-arena
-pub struct Prison<O: StableAddress, I = usize, M = HashMap<&'static < O as Deref >::Target, I>> {
+pub struct ArenaSet<O: StableAddress, I = usize, M = HashMap<&'static < O as Deref >::Target, I>> {
     map: M,
     interned: Vec<Slot<O>>,
     head: usize,
@@ -107,17 +107,17 @@ pub struct Prison<O: StableAddress, I = usize, M = HashMap<&'static < O as Deref
     _i: PhantomData<I>,
 }
 
-impl<O, I, M> Prison<O, I, M>
+impl<O, I, M> ArenaSet<O, I, M>
 where O: StableAddress,
       I: Bounded + ToPrimitive + FromPrimitive,
       M: Map {
-    /// Create a new, empty Prison.
+    /// Create a new, empty ArenaSet.
     #[inline]
     pub fn new() -> Result<Self, Error> {
         Self::with_capacity(0)
     }
 
-    /// Create a new, empty Prison with a capacity hint.
+    /// Create a new, empty ArenaSet with a capacity hint.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Result<Self, Error> {
         Self::bounded_with_capacity(
@@ -126,7 +126,7 @@ where O: StableAddress,
             capacity)
     }
 
-    /// Create a new, empty Prison with a specific maximum index and a capacity hint.
+    /// Create a new, empty ArenaSet with a specific maximum index and a capacity hint.
     #[inline]
     pub fn bounded_with_capacity(max_idx: usize, capacity: usize) -> Result<Self, Error> {
         let max_possible = I::max_value().to_usize().ok_or(Error::FromIdFailed)?
@@ -134,7 +134,7 @@ where O: StableAddress,
         if max_idx > max_possible {
             return Err(Error::IdOverflow);
         }
-        Ok(Prison {
+        Ok(ArenaSet {
             map: M::with_capacity(capacity),
             max_idx: max_idx,
             head: !0,
@@ -146,7 +146,7 @@ where O: StableAddress,
     /// Get the number of interned items.
     ///
     /// ```
-    /// let mut p = shawshank::string_prison();
+    /// let mut p = shawshank::string_arena_set();
     /// assert_eq!(p.intern("hello"), Ok(0));
     /// assert_eq!(p.intern("world"), Ok(1));
     /// assert_eq!(p.count(), 2);
@@ -171,7 +171,7 @@ where O: StableAddress,
     /// ```
     /// use std::sync::Arc;
     ///
-    /// let mut p = shawshank::byte_solitary();
+    /// let mut p = shawshank::byte_stadium_set();
     /// assert_eq!(p.intern(vec![1,2,3]), Ok(0));
     /// let s1: &Vec<u8> = p.resolve(0).unwrap();
     /// let s2: &Arc<Vec<u8>> = p.resolve(0).unwrap();
@@ -192,7 +192,7 @@ where O: StableAddress,
 }
 
 // couldn't figure out how to get traits to abstract the differences
-// between Prison and Solitary, so had to resort to macros
+// between ArenaSet and StatiumSet, so had to resort to macros
 
 macro_rules! insert {
     ( $this:ident, $item:ident, $to_owned:expr ) => { {
@@ -289,7 +289,7 @@ macro_rules! shrink {
     } }
 }
 
-impl<O, I, M> Prison<O, I, M>
+impl<O, I, M> ArenaSet<O, I, M>
 where O: StableAddress,
       O::Target: 'static,
       I: Copy + ToPrimitive + FromPrimitive + Bounded,
@@ -304,15 +304,15 @@ where O: StableAddress,
     /// `item` is generic so that either a reference or owned type may be passed.
     ///
     /// ```
-    /// let mut p = shawshank::string_prison();
+    /// let mut p = shawshank::string_arena_set();
     /// assert_eq!(p.intern("hello"), Ok(0));
     /// assert_eq!(p.intern(String::from("hello")), Ok(0));
     /// ```
     ///
     /// Complexity: _O(max([`M::get(K)`], [`M::insert(K,V)`]))_
     ///
-    /// [`resolve`]: struct.Prison.html#method.resolve
-    /// [`shrink`]: struct.Prison.html#method.shrink
+    /// [`resolve`]: struct.ArenaSet.html#method.resolve
+    /// [`shrink`]: struct.ArenaSet.html#method.shrink
     /// [`M::get(K)`]: trait.Map.html#tymethod.get
     /// [`M::insert(K,V)`]: trait.Map.html#tymethod.insert
     pub fn intern<Q>(&mut self, item: Q) -> Result<I, Error>
@@ -327,7 +327,7 @@ where O: StableAddress,
     /// will fail. If the item is interned again, it will get a different ID.
     ///
     /// ```
-    /// let mut p = shawshank::string_prison();
+    /// let mut p = shawshank::string_arena_set();
     /// assert_eq!(p.intern("hello"), Ok(0));
     /// assert_eq!(p.intern("world"), Ok(1));
     /// assert_eq!(p.disintern(0), Ok("hello".into()));
@@ -336,8 +336,8 @@ where O: StableAddress,
     ///
     /// Complexity: _O([`M::remove(K)`])_
     ///
-    /// [`resolve`]: struct.Prison.html#method.resolve
-    /// [`shrink`]: struct.Prison.html#method.shrink
+    /// [`resolve`]: struct.ArenaSet.html#method.resolve
+    /// [`shrink`]: struct.ArenaSet.html#method.shrink
     /// [`M::remove(K)`]: trait.Map.html#tymethod.remove
     pub fn disintern<'a, U: Borrow<I>>(&'a mut self, id: U) -> Result<O, Error> {
         disintern!(self, id)
@@ -353,7 +353,7 @@ where O: StableAddress,
     /// ```
     /// use std::collections::BTreeMap;
     ///
-    /// let mut p = shawshank::string_prison();
+    /// let mut p = shawshank::string_arena_set();
     /// assert_eq!(p.intern("hello"), Ok(0));
     /// assert_eq!(p.intern("world"), Ok(1));
     /// assert_eq!(p.disintern(0), Ok("hello".into()));
@@ -372,18 +372,18 @@ where O: StableAddress,
     }
 }
 
-/// Specialization of [`Prison`] where `O::Target: StableAddress`.
+/// Specialization of [`ArenaSet`] where `O::Target: StableAddress`.
 ///
 /// Example: if `O = Arc<Vec<u8>>`, then `O::Target = Vec<u8>`. Therefore,
 /// the map `M` can be `HashMap<&'static u8, usize>`, rather than the
-/// `HashMap<&'static Vec<u8>, usize>` that [`Prison`] would use.
+/// `HashMap<&'static Vec<u8>, usize>` that [`ArenaSet`] would use.
 /// [`intern`] can similarly accept `&'a [u8]` instead of `&'a Vec<u8>`.
 ///
-/// [`Prison`]: struct.Prison.html
-/// [`intern`]: struct.Solitary.html#method.intern
-pub struct Solitary<O: StableAddress<Target = R>, R: ? Sized + StableAddress = < O as Deref >::Target, I = usize, M = HashMap<&'static < R as Deref >::Target, I>>(pub Prison<O, I, M>);
+/// [`ArenaSet`]: struct.ArenaSet.html
+/// [`intern`]: struct.StatiumSet.html#method.intern
+pub struct StatiumSet<O: StableAddress<Target = R>, R: ? Sized + StableAddress = < O as Deref >::Target, I = usize, M = HashMap<&'static < R as Deref >::Target, I>>(pub ArenaSet<O, I, M>);
 
-impl<O, R, I, M> Solitary<O, R, I, M>
+impl<O, R, I, M> StatiumSet<O, R, I, M>
 where O: StableAddress<Target = R>,
       R: 'static + StableAddress,
       I: Copy + ToPrimitive + FromPrimitive + Bounded,
@@ -395,12 +395,12 @@ where O: StableAddress<Target = R>,
     /// use std::collections::HashMap;
     /// use std::sync::Arc;
     ///
-    /// let mut p = shawshank::byte_solitary();
+    /// let mut p = shawshank::byte_stadium_set();
     /// assert_eq!(p.intern(&[1,2,3][..]), Ok(0));
     /// assert_eq!(p.intern(vec![1,2,3]), Ok(0));
     /// ```
     ///
-    /// [`intern`]: struct.Prison.html#method.intern
+    /// [`intern`]: struct.ArenaSet.html#method.intern
     pub fn intern<Q>(&mut self, item: Q) -> Result<I, Error>
         where Q: Borrow<< O::Target as Deref >::Target>,
               O::Target: From<Q>,
@@ -416,12 +416,12 @@ where O: StableAddress<Target = R>,
     /// use std::ops::Deref;
     /// use std::sync::Arc;
     ///
-    /// let mut p = shawshank::byte_solitary();
+    /// let mut p = shawshank::byte_stadium_set();
     /// assert_eq!(p.intern(&[1,2,3][..]), Ok(0));
     /// assert_eq!(p.disintern(0).unwrap().deref().deref(), &[1,2,3]);
     /// ```
     ///
-    /// [`disintern`]: struct.Prison.html#method.disintern
+    /// [`disintern`]: struct.ArenaSet.html#method.disintern
     pub fn disintern<'a, U: Borrow<I>>(&'a mut self, id: U) -> Result<O, Error> {
         let ref mut this = self.0;
         disintern!(this, id)
@@ -433,13 +433,13 @@ where O: StableAddress<Target = R>,
     /// use std::collections::HashMap;
     /// use std::sync::Arc;
     ///
-    /// let mut p = shawshank::byte_solitary();
+    /// let mut p = shawshank::byte_stadium_set();
     /// assert_eq!(p.intern(&[1,2,3][..]), Ok(0));
     /// let s1: &Vec<u8> = p.resolve(0).unwrap();
     /// let s1: &Arc<Vec<u8>> = p.resolve(0).unwrap();
     /// ```
     ///
-    /// [`resolve`]: struct.Prison.html#method.resolve
+    /// [`resolve`]: struct.ArenaSet.html#method.resolve
     #[inline]
     pub fn resolve<'a, U, Q: ? Sized>(&'a self, id: U) -> Result<&'a Q, Error>
         where U: Borrow<I>,
@@ -449,7 +449,7 @@ where O: StableAddress<Target = R>,
 
     /// Analogue of [`shrink`].
     ///
-    /// [`shrink`]: struct.Prison.html#method.shrink
+    /// [`shrink`]: struct.ArenaSet.html#method.shrink
     pub fn shrink<T: Map<Key = I, Value = I>>(&mut self) -> T
     {
         let ref mut this = self.0;
@@ -457,16 +457,16 @@ where O: StableAddress<Target = R>,
     }
 }
 
-/// Errors that may occur when using a [`Prison`].
-/// [`Prison`]: struct.Prison.html
+/// Errors that may occur when using a [`ArenaSet`].
+/// [`ArenaSet`]: struct.ArenaSet.html
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub enum Error {
     /// The ID does not represent an interned item. This could mean either that the ID
     /// has never been returned from a call to [`intern`]; or was subsequently passed
     /// to [`disintern`].
     ///
-    /// [`intern`]: struct.Prison.html#method.intern
-    /// [`disintern`]: struct.Prison.html#method.disintern
+    /// [`intern`]: struct.ArenaSet.html#method.intern
+    /// [`disintern`]: struct.ArenaSet.html#method.disintern
     InvalidId,
 
     /// Could not convert an ID type to a `Vec` index.
@@ -477,11 +477,11 @@ pub enum Error {
 
     /// The ID type cannot uniquely represent any more items.
     ///
-    /// For instance, if `I = u8`, and there are 256 items in a [`Prison`],
+    /// For instance, if `I = u8`, and there are 256 items in a [`ArenaSet`],
     /// further calls to [`intern`] will fail with this error.
     ///
-    /// [`Prison`]: struct.Prison.html
-    /// [`intern`]: struct.Prison.html#method.intern
+    /// [`ArenaSet`]: struct.ArenaSet.html
+    /// [`intern`]: struct.ArenaSet.html#method.intern
     IdOverflow,
 }
 

--- a/src/benches.rs
+++ b/src/benches.rs
@@ -4,10 +4,10 @@ use super::*;
 use test::Bencher;
 use traits::Map;
 
-fn prefilled<M: Map<Key = &'static str, Value = u32>, F, P>(count: u32, f: F) -> (Prison<String, u32, M>, Vec<P>)
+fn prefilled<M: Map<Key = &'static str, Value = u32>, F, P>(count: u32, f: F) -> (ArenaSet<String, u32, M>, Vec<P>)
     where F: Fn(String, u32) -> P {
     let mut rng = thread_rng();
-    let mut p = Prison::new().unwrap();
+    let mut p = ArenaSet::new().unwrap();
     let mut path = Vec::new();
     for i in 0..count {
         let s = format!("{}{}", rng.next_u64(), i);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,9 +6,9 @@ use std::ops::Deref;
 use num::{Bounded, ToPrimitive, FromPrimitive};
 use owning_ref::StableAddress;
 
-use prison::{Error, Prison, Solitary};
+use arena_set::{Error, ArenaSet, StatiumSet};
 
-/// Flexible builder for [`Prison`].
+/// Flexible builder for [`ArenaSet`].
 ///
 /// ```
 /// use std::sync::Arc;
@@ -19,13 +19,13 @@ use prison::{Error, Prison, Solitary};
 /// assert_eq!(p1.resolve(0), Ok("hello"));
 ///
 /// let b2 = shawshank::Builder::<Arc<String>>::new();
-/// let mut p2 = b2.solitary_hash().unwrap();
+/// let mut p2 = b2.stadium_set_hash().unwrap();
 /// assert_eq!(p2.intern("hello"), Ok(0));
 /// let s: &String = p2.resolve(0).unwrap();
 /// assert_eq!(s.as_str(), "hello");
 /// ```
 ///
-/// [`Prison`]: struct.Prison.html
+/// [`ArenaSet`]: struct.ArenaSet.html
 pub struct Builder<O, I = usize> {
     _o: PhantomData<O>,
     _i: PhantomData<I>,
@@ -50,18 +50,18 @@ impl<O, I> Builder<O, I>
 where O: StableAddress,
       I: Bounded + ToPrimitive + FromPrimitive
 {
-    /// Create an empty [`Prison`] that uses a `HashMap`.
-    /// [`Prison`]: struct.Prison.html
-    pub fn hash(&self) -> Result<Prison<O, I, HashMap<&'static O::Target, I>>, Error>
+    /// Create an empty [`ArenaSet`] that uses a `HashMap`.
+    /// [`ArenaSet`]: struct.ArenaSet.html
+    pub fn hash(&self) -> Result<ArenaSet<O, I, HashMap<&'static O::Target, I>>, Error>
         where O::Target: Eq + Hash {
-        Prison::new()
+        ArenaSet::new()
     }
 
-    /// Create an empty [`Prison`] that uses a `BTreeMap`.
-    /// [`Prison`]: struct.Prison.html
-    pub fn btree(&self) -> Result<Prison<O, I, BTreeMap<&'static O::Target, I>>, Error>
+    /// Create an empty [`ArenaSet`] that uses a `BTreeMap`.
+    /// [`ArenaSet`]: struct.ArenaSet.html
+    pub fn btree(&self) -> Result<ArenaSet<O, I, BTreeMap<&'static O::Target, I>>, Error>
         where O::Target: Eq + Ord {
-        Prison::new()
+        ArenaSet::new()
     }
 }
 
@@ -71,17 +71,17 @@ where O: StableAddress,
       < O::Target as Deref >::Target: 'static,
       I: Bounded + ToPrimitive + FromPrimitive
 {
-    /// Create an empty [`Solitary`] that uses a `HashMap`.
-    /// [`Solitary`]: struct.Solitary.html
-    pub fn solitary_hash(&self) -> Result<Solitary<O, O::Target, I, HashMap<&'static < O::Target as Deref >::Target, I>>, Error>
+    /// Create an empty [`StatiumSet`] that uses a `HashMap`.
+    /// [`StatiumSet`]: struct.StatiumSet.html
+    pub fn stadium_set_hash(&self) -> Result<StatiumSet<O, O::Target, I, HashMap<&'static < O::Target as Deref >::Target, I>>, Error>
         where < O::Target as Deref >::Target: Eq + Hash {
-        Prison::new().map(|p| Solitary(p))
+        ArenaSet::new().map(|p| StatiumSet(p))
     }
 
-    /// Create an empty [`Solitary`] that uses a `BTreeMap`.
-    /// [`Solitary`]: struct.Solitary.html
-    pub fn solitary_btree(&self) -> Result<Solitary<O, O::Target, I, BTreeMap<&'static < O::Target as Deref >::Target, I>>, Error>
+    /// Create an empty [`StatiumSet`] that uses a `BTreeMap`.
+    /// [`StatiumSet`]: struct.StatiumSet.html
+    pub fn stadium_set_btree(&self) -> Result<StatiumSet<O, O::Target, I, BTreeMap<&'static < O::Target as Deref >::Target, I>>, Error>
         where < O::Target as Deref >::Target: Eq + Ord {
-        Prison::new().map(|p| Solitary(p))
+        ArenaSet::new().map(|p| StatiumSet(p))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! [`Prison`] is an efficient, generic internment structure.
+//! [`ArenaSet`] is an efficient, generic internment structure.
 //!
-//! [`Prison`]: struct.Prison.html
+//! [`ArenaSet`]: struct.ArenaSet.html
 
 #![cfg_attr(feature = "unstable", feature(test))]
 
@@ -13,8 +13,8 @@ extern crate rand;
 #[cfg(all(feature = "unstable", test))]
 extern crate test;
 
+mod arena_set;
 mod builder;
-mod prison;
 mod traits;
 mod utility;
 #[macro_use] mod macros;
@@ -23,6 +23,6 @@ mod utility;
 mod benches;
 
 pub use builder::{Builder, builder};
-pub use prison::{Error, Prison, Solitary};
+pub use arena_set::{Error, ArenaSet, StatiumSet};
 pub use traits::Map;
-pub use utility::{string_prison, byte_prison, string_solitary, byte_solitary};
+pub use utility::{string_arena_set, byte_arena_set, string_stadium_set, byte_stadium_set};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,8 @@
 /// Facilitates defining tuple structs that may be used as custom IDs.
 ///
-/// See the [section from `Prison`][ex] for an example.
+/// See the [section from `ArenaSet`][ex] for an example.
 ///
-/// [ex]: struct.Prison.html#custom-id-types
+/// [ex]: struct.ArenaSet.html#custom-id-types
 #[macro_export]
 macro_rules! custom_intern_id {
     ( $name:ident, $base:ty, $min:expr, $max:expr ) => {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,21 +1,21 @@
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 
-/// The interface for the key-value map internal to a [`Prison`].
+/// The interface for the key-value map internal to a [`ArenaSet`].
 ///
 /// The Entry API is not supported, because it can't be used as is, anyway:
 /// the reference passed as a key to `entry(K)` would be to something outside
-/// the prison, which we absolutely don't want to store in the map. The Entry
+/// the arena_set, which we absolutely don't want to store in the map. The Entry
 /// API would have to be extended to allow changing the key before insertion.
 ///
-/// [`Prison`]: struct.Prison.html
+/// [`ArenaSet`]: struct.ArenaSet.html
 pub trait Map {
     type Key;
     type Value;
 
     /// Create an empty map.
     ///
-    /// This is required for `Prison` to function properly.
+    /// This is required for `ArenaSet` to function properly.
     fn new() -> Self;
 
     /// Create an empty map with a capacity hint.
@@ -30,17 +30,17 @@ pub trait Map {
     /// Insert a key-value pair. If there was already an entry for the key,
     /// it gets replaced, and the previous returned.
     ///
-    /// This is required for `Prison` to function properly.
+    /// This is required for `ArenaSet` to function properly.
     fn insert(&mut self, Self::Key, Self::Value) -> Option<Self::Value>;
 
     /// Get a value by its key.
     ///
-    /// This is required for `Prison` to function properly.
+    /// This is required for `ArenaSet` to function properly.
     fn get(&self, Self::Key) -> Option<&Self::Value>;
 
     /// Remove a pair by its key.
     ///
-    /// This is required for `Prison` to function properly.
+    /// This is required for `ArenaSet` to function properly.
     fn remove(&mut self, Self::Key) -> Option<Self::Value>;
 
     /// Reduce memory usage as much as possible.

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,28 +1,28 @@
 use std::sync::Arc;
 
 use builder::builder;
-use prison::{Prison, Solitary};
+use arena_set::{ArenaSet, StatiumSet};
 
-/// Create a [`Prison`] for `String` with a `HashMap` and an ID of `usize`.
-/// [`Prison`]: struct.Prison.html
-pub fn string_prison() -> Prison<String> {
+/// Create a [`ArenaSet`] for `String` with a `HashMap` and an ID of `usize`.
+/// [`ArenaSet`]: struct.ArenaSet.html
+pub fn string_arena_set() -> ArenaSet<String> {
     builder().hash().unwrap()
 }
 
-/// Create a [`Prison`] for `Vec<u8>` with a `HashMap` and an ID of `usize`.
-/// [`Prison`]: struct.Prison.html
-pub fn byte_prison() -> Prison<Vec<u8>> {
+/// Create a [`ArenaSet`] for `Vec<u8>` with a `HashMap` and an ID of `usize`.
+/// [`ArenaSet`]: struct.ArenaSet.html
+pub fn byte_arena_set() -> ArenaSet<Vec<u8>> {
     builder().hash().unwrap()
 }
 
-/// Create a [`Solitary`] for `Arc<String>` with a `HashMap` and an ID of `usize`.
-/// [`Solitary`]: struct.Solitary.html
-pub fn string_solitary() -> Solitary<Arc<String>> {
-    builder().solitary_hash().unwrap()
+/// Create a [`StatiumSet`] for `Arc<String>` with a `HashMap` and an ID of `usize`.
+/// [`StatiumSet`]: struct.StatiumSet.html
+pub fn string_stadium_set() -> StatiumSet<Arc<String>> {
+    builder().stadium_set_hash().unwrap()
 }
 
-/// Create a [`Solitary`] for `Arc<Vec<u8>>` with a `HashMap` and an ID of `usize`.
-/// [`Solitary`]: struct.Solitary.html
-pub fn byte_solitary() -> Solitary<Arc<Vec<u8>>> {
-    builder().solitary_hash().unwrap()
+/// Create a [`StatiumSet`] for `Arc<Vec<u8>>` with a `HashMap` and an ID of `usize`.
+/// [`StatiumSet`]: struct.StatiumSet.html
+pub fn byte_stadium_set() -> StatiumSet<Arc<Vec<u8>>> {
+    builder().stadium_set_hash().unwrap()
 }


### PR DESCRIPTION
Rename `Prison` and `Solitary` structures to `ArenaSet` and `StadiumSet`. Snake case occurrances are renamed similarly to `arena_set` and `stadium_set`.

Set version to 0.2.0, since this breaks the previous interface.