### PR TITLE
Use `num-traits` instead of `num`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 unstable = []
 
 [dependencies]
-num = "0.1"
+num-traits = "0.1"
 owning_ref = "0.2"
 
 [dev-dependencies]

--- a/src/arena_set.rs
+++ b/src/arena_set.rs
@@ -4,7 +4,7 @@ use std::mem;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
-use num::{Bounded, ToPrimitive, FromPrimitive};
+use num_traits::{Bounded, ToPrimitive, FromPrimitive};
 use owning_ref::StableAddress;
 
 use traits::Map;
@@ -59,15 +59,15 @@ use traits::Map;
 /// internal map, and converting to and from `usize` as needed. [`intern`]
 /// returns [`Error::IdOverflow`] if there are no more unique IDs available.
 ///
-/// The `ToPrimitive`/`FromPrimitive` traits of the `num` crate are used to
-/// perform the conversions. If these ever return `None` during an operation,
+/// The `ToPrimitive`/`FromPrimitive` traits of the `num-traits` crate are used
+/// to perform the conversions. If these ever return `None` during an operation,
 /// it will fail with [`Error::FromIdFailed`]/[`Error::ToIdFailed`].
 ///
 /// The [`custom_intern_id!`] macro reduces the boilerplate to set thes up.
 ///
 /// ```
 /// #[macro_use] extern crate shawshank;
-/// extern crate num;
+/// extern crate num_traits;
 ///
 /// use shawshank::Error;
 ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
-use num::{Bounded, ToPrimitive, FromPrimitive};
+use num_traits::{Bounded, ToPrimitive, FromPrimitive};
 use owning_ref::StableAddress;
 
 use arena_set::{Error, ArenaSet, StadiumSet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(feature = "unstable", feature(test))]
 
-extern crate num;
+extern crate num_traits;
 extern crate owning_ref;
 
 #[cfg(test)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,7 +9,7 @@ macro_rules! custom_intern_id {
         #[derive(Clone, Copy, Eq, PartialEq, Debug)]
         struct $name($base);
 
-        impl ::num::Bounded for $name {
+        impl ::num_traits::Bounded for $name {
             fn min_value() -> Self {
                 $name($min)
             }
@@ -18,14 +18,14 @@ macro_rules! custom_intern_id {
             }
         }
 
-        impl ::num::ToPrimitive for $name {
+        impl ::num_traits::ToPrimitive for $name {
             fn to_i64(&self) -> Option<i64> { self.0.to_i64() }
             fn to_u64(&self) -> Option<u64> { self.0.to_u64() }
         }
 
-        impl ::num::FromPrimitive for $name {
-            fn from_i64(n: i64) -> Option<Self> { <$base as ::num::FromPrimitive>::from_i64(n).map(|x| $name(x)) }
-            fn from_u64(n: u64) -> Option<Self> { <$base as ::num::FromPrimitive>::from_u64(n).map(|x| $name(x)) }
+        impl ::num_traits::FromPrimitive for $name {
+            fn from_i64(n: i64) -> Option<Self> { <$base as ::num_traits::FromPrimitive>::from_i64(n).map(|x| $name(x)) }
+            fn from_u64(n: u64) -> Option<Self> { <$base as ::num_traits::FromPrimitive>::from_u64(n).map(|x| $name(x)) }
         }
     };
     ( $name:ident, $base:ty ) => {


### PR DESCRIPTION
Avoid pulling in unnecessary dependencies such that `num-bigint` and `num-rational`.